### PR TITLE
Get data

### DIFF
--- a/scripts/tp-kappa-target
+++ b/scripts/tp-kappa-target
@@ -19,8 +19,6 @@ parser.add_argument('-c', '--colour', metavar='colour', nargs='+',
 parser.add_argument('-d', '--direction', metavar='direction', default='avg',
                     help='direction for anisotropic data. Accepts a-c/ '
                          'x-z or average/ avg. Default: avg.')
-parser.add_argument('--nodata', action='store_true',
-                    help='do not print data file.')
 parser.add_argument('-e', '--extension', metavar='extension', nargs='+',
                     default=['pdf'],
                     help='output extension(s). Default: pdf.')
@@ -60,10 +58,6 @@ import tp
 axes = tp.axes.one_large if args.large else tp.axes.one
 if len(args.colour) == 1:
     args.colour = args.colour[0]
-if args.nodata:
-    ztdata = None
-else:
-    ztdata = 'kl-{}.hdf5'.format(args.direction)
 
 try:
     edata = tp.data.load.amset(args.file)
@@ -79,8 +73,7 @@ cbar = tp.plot.heatmap.add_kappa_target(ax, edata, zt=args.zt,
                                         kind=args.kind, colour=args.colour,
                                         xmin=args.xmin, xmax=args.xmax,
                                         ymin=args.ymin, ymax=args.ymax,
-                                        cmin=args.cmin, cmax=args.cmax,
-                                        output=ztdata)
+                                        cmin=args.cmin, cmax=args.cmax)
 
 if args.large:
     cbar.set_label(tp.settings.large_labels()['lattice_thermal_conductivity'])

--- a/scripts/tp-ztmap
+++ b/scripts/tp-ztmap
@@ -20,8 +20,6 @@ parser.add_argument('-c', '--colour', metavar='colour', nargs='+',
 parser.add_argument('-d', '--direction', metavar='direction', default='avg',
                     help='direction for anisotropic data. Accepts a-c/ '
                          'x-z or average/ avg. Default: avg.')
-parser.add_argument('--nodata', action='store_true',
-                    help='do not print data file.')
 parser.add_argument('-e', '--extension', metavar='extension', nargs='+',
                     default=['pdf'],
                     help='output extension(s). Default: pdf.')
@@ -64,10 +62,6 @@ import tp
 axes = tp.axes.one_large if args.large else tp.axes.one
 if len(args.colour) == 1:
     args.colour = args.colour[0]
-if args.nodata:
-    ztdata = None
-else:
-    ztdata = 'zt-{}-{}.hdf5'.format(args.type, args.direction)
 
 try:
     edata = tp.data.load.amset(args.file)
@@ -92,7 +86,7 @@ tp.plot.heatmap.add_ztmap(ax, edata, kdata=kdata, direction=args.direction,
                           xinterp=args.interpolate, yinterp=args.interpolate,
                           kind=args.kind, colour=args.colour, xmin=args.xmin,
                           xmax=args.xmax, ymin=args.ymin, ymax=args.ymax,
-                          cmin=args.cmin, cmax=args.cmax, output=ztdata)
+                          cmin=args.cmin, cmax=args.cmax)
 
 for ext in args.extension:
     plt.savefig('{}.{}'.format(args.output, ext))

--- a/tp/data/load.py
+++ b/tp/data/load.py
@@ -38,7 +38,7 @@ def amset(filename, quantities=['temperature', 'doping', 'seebeck',
         filename : str
             filepath.
 
-        quantites : dict, optional
+        quantites : str or list, optional
             values to extract. Default: temperature, doping, seebeck,
             conductivity, electronic_thermal_conductivity.
 
@@ -131,7 +131,7 @@ def amset_mesh(filename, quantities=['temperature', 'doping',
         filename : str
             filepath.
 
-        quantites : dict, optional
+        quantites : str or list, optional
             values to extract. Accepts AMSET keys, without spin
             channels, which are dealt with in the spin variable.
             Default: temperature, doping, scattering_rates,
@@ -236,7 +236,7 @@ def boltztrap(filename, quantities=['temperature', 'doping', 'seebeck',
         filename : str
             filepath.
 
-        quantites : dict, optional
+        quantites : str or list, optional
             values to extract. Accepts boltztrap.hdf5 keys.
             Default: temperature, doping, seebeck, conductivity,
             electronic_thermal_conductivity.
@@ -304,12 +304,10 @@ def boltztrap(filename, quantities=['temperature', 'doping', 'seebeck',
 
     return data2
 
-def phono3py(filename, quantities=['kappa', 'temperature'],
-             write_lifetime=False, write_mfp=False, write_occupation=False):
+def phono3py(filename, quantities=['kappa', 'temperature']):
     """Loads Phono3py data.
 
-    Can also calculate lifetimes, mean free paths and occupations, which
-    can be written to a file.
+    Can also calculate lifetimes, mean free paths and occupations.
     Includes unit conversions and outputs units for all the data (see
     tp.settings). Also corrects mode_kappa for different phono3py
     versions.
@@ -320,18 +318,9 @@ def phono3py(filename, quantities=['kappa', 'temperature'],
         filename : str
             filepath.
 
-        quantities : list, optional
+        quantities : str or list, optional
             values to extract. Accepts Phono3py keys, lifetime,
             mean_free_path and occupation. Default: kappa, temperature.
-        write_lifetime : bool, optional
-            write lifetimes to a new hdf5 file if in quantites.
-            Default: False.
-        write_mfp : bool, optional
-            write mean free paths to a new hdf5 file if in quantities.
-            Default: False.
-        write_occupation : bool, optional
-            write occupations to a new hdf5 file if in quantities.
-            Default: False.
 
     Returns
     -------
@@ -365,7 +354,7 @@ def phono3py(filename, quantities=['kappa', 'temperature'],
 
     if 'temperature' not in quantities:
         for q in quantities:
-            if q in hast:
+            if q in hast or (q in tnames and tnames[q] in hast):
                 quantities.append('temperature')
                 break
 
@@ -396,15 +385,6 @@ def phono3py(filename, quantities=['kappa', 'temperature'],
                         for t in data['temperature'][()]]
         if q2 in units:
             data2['meta']['units'][q2] = units[q2]
-
-    # write calculated data (loath to mess with original file)
-    for write, q in zip([write_lifetime, write_mfp, write_occupation],
-                        ['lifetime', 'mean_free_path', 'occupation']):
-        if write and q in quantities:
-            data3 = h5py.File('{}-{}'.format(q, filename), 'w')
-            for q2 in [q, 'temperature', 'qpoint']:
-                data3.create_dataset(q2, np.shape(data2[q2]), data=data2[q2])
-            data3.close()
 
     # check mode_kappa and correct for certain phono3py versions
     if 'mode_kappa' in data2:
@@ -583,7 +563,7 @@ def get_path(yamldata):
     Arguments
     ---------
 
-        yamldata : str
+        yamldata : dict
             raw phonopy dispersion data (i.e. from yaml.safe_load).
 
     Returns

--- a/tp/data/load.py
+++ b/tp/data/load.py
@@ -117,9 +117,9 @@ def amset(filename, quantities=['temperature', 'doping', 'seebeck',
         if q in hasdope:
             # temperature index first for consistency with other codes
             if q in hastype:
-                data2[q2][t] = np.array(data2[q2][t])[di]
-                if q in hastemp:
-                    for t in data2[q2]:
+                for t in data2[q2]:
+                    data2[q2][t] = np.array(data2[q2][t])[di]
+                    if q in hastemp:
                         data2[q2][t] = np.swapaxes(data2[q2][t],0,1)
             else:
                 data2[q2] = np.array(data2[q2])[di]
@@ -256,13 +256,17 @@ def amset_mesh(filename, quantities=['temperature', 'doping',
         if q in hasdope:
             # temperature in first index for consistency with other codes
             if q in hastype:
-                data2[q2] = np.array(data2[q2])[:,di]
                 if q in hastemp:
                     data2[q2] = np.swapaxes(data2[q2],1,2)
+                    data2[q2] = np.array(data2[q2])[:,:,di]
+                else:
+                    data2[q2] = np.array(data2[q2])[:,di]
             else:
-                data2[q2] = np.array(data2[q2])[di]
                 if q in hastemp:
                     data2[q2] = np.swapaxes(data2[q2],0,1)
+                    data2[q2] = np.array(data2[q2])[:,di]
+                else:
+                    data2[q2] = np.array(data2[q2])[di]
         if q2 in units:
             data2['meta']['units'][q2] = units[q2]
 

--- a/tp/data/run.py
+++ b/tp/data/run.py
@@ -7,12 +7,14 @@ Functions
 """
 
 import numpy as np
+import os
+import shutil
 import tp
 
 def boltztrap(tmax=1001, tstep=50, tmin=None, doping=np.logspace(18, 21, 17),
               ke_mode='boltzmann', vasprun='vasprun.xml', kpoints=None,
               relaxation_time=1e-14, lpfac=10, run=True, analyse=True,
-              output='boltztrap.hdf5', **kwargs):
+              output='boltztrap.hdf5', run_dir='.', clean=False, **kwargs):
     """Runs BoltzTraP from a VASP density of states (DoS).
 
     Runs quicker and more robustly than the pymatgen from_files version,
@@ -64,6 +66,10 @@ def boltztrap(tmax=1001, tstep=50, tmin=None, doping=np.logspace(18, 21, 17),
             analyse BoltzTraP. Default: True.
         output : str, optional
             output hdf5 filename. Default: boltztrap.hdf5.
+        run_dir : str, optional
+            path to run boltztrap in. Default: current directory.
+        clean : bool, optional
+            remove boltztrap directory post-run. Default: False.
 
         kwargs
             passed to pymatgen.electronic.structure.boltztrap.BoltztrapRunner.
@@ -131,14 +137,16 @@ def boltztrap(tmax=1001, tstep=50, tmin=None, doping=np.logspace(18, 21, 17),
 
     # check inputs
 
-    for name, value in zip(['run', 'analyse'],
-                           [ run,   analyse]):
+    for name, value in zip(['run', 'analyse', 'clean'],
+                           [ run,   analyse,   clean]):
         assert isinstance(value, bool), '{} must be True or False'.format(name)
 
     ke_mode = ke_mode.lower()
     ke_modes =  ['boltzmann', 'wiedemann', 'snyder']
     assert ke_mode in ke_modes, 'ke_mode must be {} or {}.'.format(
                                 ', '.join(ke_modes[:-1]), ke_modes[-1])
+
+    run_dir = os.path.abspath(run_dir)
 
     tmax += tstep
     tmin = tstep if tmin is None else tmin
@@ -154,31 +162,29 @@ def boltztrap(tmax=1001, tstep=50, tmin=None, doping=np.logspace(18, 21, 17),
             btr = BoltztrapRunner(bs, nelect, doping=list(doping), tmax=tmax,
                                   tgrid=tstep, soc=soc, lpfac=lpfac, **kwargs)
             print('Running Boltztrap...', end='')
-            btr_dir = btr.run(path_dir='.')
+            btr_dir = btr.run(path_dir=run_dir)
             print('Done.')
         except BoltztrapError:
             bs = vr.get_band_structure(line_mode=True,kpoints_filename=kpoints)
             nelect = vr.parameters['NELECT']
             btr = BoltztrapRunner(bs, nelect, doping=list(doping), tmax=tmax,
                                   tgrid=tstep, soc=soc, lpfac=lpfac, **kwargs)
-            btr_dir = btr.run(path_dir='.')
+            btr_dir = btr.run(path_dir=run_dir)
             print('Done.')
-
 
         """
         Detects whether the BoltzTraP build on this computer writes the
         doping concentrations correctly, and if it doesn't, writes them.
         """
-        with open('boltztrap/boltztrap.outputtrans', 'r') as f:
+        with open(os.path.join(btr_dir, 'boltztrap.outputtrans'), 'r') as f:
             line = f.readlines()[-2]
         if len(line) >= 23 and line[:23] == ' Calling FermiIntegrals':
             with open(os.path.join(btr_dir, 'boltztrap.outputtrans'),'a') as f:
                 for i, x in enumerate(np.concatenate((doping, -doping))):
                     f.write(
                    'Doping level number {} n = {} carriers/cm3\n'.format(i, x))
-
     else:
-        btr_dir = 'boltztrap'
+        btr_dir = os.path.join(run_dir, 'boltztrap')
 
     if analyse: # run boltztrap from boltztrap directory -> hdf5 file
         print('Analysing Boltztrap...', end='')
@@ -250,5 +256,9 @@ def boltztrap(tmax=1001, tstep=50, tmin=None, doping=np.logspace(18, 21, 17),
         print('Done.')
 
         tp.data.save.hdf5(data, output)
+
+        if clean:
+            shutil.rmtree(btr_dir)
+            os.remove(os.path.join(run_dir, 'boltztrap.out'))
 
     return

--- a/tp/data/save.py
+++ b/tp/data/save.py
@@ -1,7 +1,279 @@
-"""Utility to save to hdf5"""
+"""Utilities to save data
+
+Functions:
+    phono3py: save calculated properties to hdf5.
+    zt: save zt to hdf5 and highlights to yaml.
+
+    hdf5: save nested dictionaries to hdf5 (up to depth 3).
+    prompt: prompt before overwriting input
+"""
 
 import h5py
 import numpy as np
+from scipy.interpolate import interp1d, interp2d
+from sys import exit
+import tp
+import yaml
+
+def phono3py(filename, quantities, output='tp-phono3py', force=False):
+    """Save calculated properties to hdf5.
+
+    Also saves dependant properties (temperature etc.) and metadata.
+
+    Arguments
+    ---------
+
+        filename : str
+            filepath.
+        quantities : str or list
+            values to save. Accepts any phonop3y properties, but only
+            lifetime, mean_free_path and/ or occupation are recommended.
+
+        output : str, optional
+            output filename (no extension). Default: tp-phono3py.
+        force : bool, optional
+            force overwrite input file. Default: False.
+
+    Returns
+    -------
+
+        none
+            instead writes to hdf5.
+    """
+
+    if not force:
+        prompt(filename, '{}.hdf5'.format(output))
+    hdf5(tp.data.load.phono3py(filename, quantities), '{}.hdf5'.format(output))
+
+    return
+
+def zt(efile, kfile=None, direction='avg', doping='n', tinterp=None,
+       dinterp=None, kind='linear', output='tp-zt', force=False):
+    """Save zt to hdf5 and highlights to yaml.
+
+    Also saves temperature and doping and metadata.
+
+    Arguments
+    ---------
+
+        efile : str
+            electronic data filepath.
+
+        kfile : str
+            phononic data filepath.
+        direction : str, optional
+            crystal direction, accepts x-z/ a-c or average/ avg.
+            Default: average.
+        doping : str, optional
+            doping type for BoltzTraP. Must be n or p. Default: n.
+
+        tinterp : int, optional
+            density of interpolation for temperature. None turns it off.
+            Default: 200.
+        dinterp : int, optional
+            density of interpolation for doping. None turns it off.
+            Default: 200.
+        kind : str, optional
+            interpolation kind. Default: linear.
+
+        output : str, optional
+            output filename (no extension). Default: tp-zt.
+        force : bool, optional
+            force overwrite input file. Default: False.
+
+    Returns
+    -------
+
+        none
+            instead writes to hdf5, yaml and stdout.
+    """
+
+    if not force:
+        for f in [efile, kfile]:
+            prompt(f, ['{}.hdf5'.format(output), '{}.yaml'.format(output)])
+
+    try:
+        edata = tp.data.load.amset(efile)
+    except Exception:
+        edata = tp.data.load.boltztrap(efile, doping=doping)
+    edata = tp.data.resolve.resolve(edata, ['conductivity', 'seebeck',
+                                    'electronic_thermal_conductivity'],
+                                    direction=direction)
+
+    if kfile is not None:
+        kdata = tp.data.load.phono3py(kfile)
+        kdata = tp.data.resolve.resolve(kdata, 'lattice_thermal_conductivity',
+                                        direction=direction)
+        # shrink to smallest temperature
+        tmin = np.amax([edata['temperature'][0], kdata['temperature'][0]])
+        tmax = np.amin([edata['temperature'][-1], kdata['temperature'][-1]])
+        etindex = np.where((edata['temperature'] <= tmax)
+                         & (edata['temperature'] >= tmin))
+        edata['temperature'] = np.array(edata['temperature'])[etindex[0]]
+        edata['conductivity'] = np.array(edata['conductivity'])[etindex[0]]
+        edata['electronic_thermal_conductivity'] = \
+                 np.array(edata['electronic_thermal_conductivity'])[etindex[0]]
+        edata['seebeck'] = np.array(edata['seebeck'])[etindex[0]]
+        ktindex = np.where((kdata['temperature'] <= tmax)
+                         & (kdata['temperature'] >= tmin))
+        kdata['temperature'] = np.array(kdata['temperature'])[ktindex[0]]
+        kdata['lattice_thermal_conductivity'] = \
+                    np.array(kdata['lattice_thermal_conductivity'])[ktindex[0]]
+        # interpolate lattice thermal conductivity to fit electronic data
+        kinterp = interp1d(kdata['temperature'],
+                           kdata['lattice_thermal_conductivity'], kind='cubic')
+        edata['lattice_thermal_conductivity'] = kinterp(edata['temperature'])
+        edata['meta']['kappa_source'] = kdata['meta']['kappa_source']
+    else: # if lattice thermal conductivity not supplied, set to 1 W m-1 K-1
+        edata['lattice_thermal_conductivity'] = np.ones(
+                                                      len(data['temperature']))
+        edata['meta']['kappa_source'] = 'Set to 1 W m^-1 K^-1'
+    edata = tp.calculate.zt_fromdict(edata)
+
+    ztdata = {'meta': {**edata['meta'],
+                       'original_temperature': edata['temperature'][()].tolist(),
+                       'original_doping':      edata['doping'][()].tolist()}}
+    # interpolation of zt (if applicable)
+    if tinterp is not None or dinterp is not None:
+        if tinterp is None:
+            ztdata['temperature'] = edata['temperature'][()]
+        else:
+            ztdata['temperature'] = np.linspace(edata['temperature'][0],
+                                                edata['temperature'][-1],
+                                                tinterp)
+        if dinterp is None:
+            ztdata['doping'] = edata['doping'][()]
+        else:
+            ztdata['doping'] = np.geomspace(edata['doping'][0],
+                                            edata['doping'][-1], dinterp)
+
+        ztinterp = interp2d(edata['doping'], edata['temperature'], edata['zt'],
+                            kind=kind)
+        ztdata['zt'] = ztinterp(ztdata['doping'], ztdata['temperature'])
+    else:
+        ztdata['zt'] = edata['zt'][()]
+        ztdata['temperature'] = edata['temperature'][()]
+        ztdata['doping'] = edata['doping'][()]
+
+    hdf5(ztdata, '{}.hdf5'.format(output))
+
+    # highlights
+    ydata = {'meta': ztdata['meta'],
+             'max':  {}}
+
+    # max zt and corresponding temperature and doping
+    maxindex = np.where(np.round(ztdata['zt'], 10) \
+                     == np.round(np.amax(ztdata['zt']), 10))
+    ydata['max']['zt'] = ztdata['zt'].tolist()[maxindex[0][0]][maxindex[1][0]]
+    ydata['max']['temperature'] = ztdata['temperature'].tolist()[maxindex[0][0]]
+    ydata['max']['doping'] = ztdata['doping'].tolist()[maxindex[1][0]]
+
+    # max zt per temperature and corresponding doping
+    maxindices = [(i, np.where(np.round(zt, 10) \
+                            == np.round(np.amax(zt),10))[0][0]) \
+                  for i, zt in enumerate(ztdata['zt'])]
+    ydata['zt'] = [ztdata['zt'].tolist()[i][j] for i, j in maxindices]
+    ydata['temperature'] = ztdata['temperature'].tolist()
+    ydata['doping'] = [ztdata['doping'].tolist()[i] for _, i in maxindices]
+
+    with open('{}.yaml'.format(output), 'w') as f:
+        yaml.dump(ydata, f, default_flow_style=False)
+
+    print('Max ZT of {:.2f} at {:.0f} K, {:.2e} carriers cm^-3'.format(
+                                                   ydata['max']['zt'],
+                                                   ydata['max']['temperature'],
+                                                   ydata['max']['doping']))
+
+
+
+    return
+
+def kappa_target(filename, zt=2, direction='avg', doping='n', tinterp=None,
+                 dinterp=None, kind='linear', output='tp-kappa-target',
+                 force=False):
+    """Save target kappa_l to hdf5.
+
+    Also saves temperature and doping and metadata.
+
+    Arguments
+    ---------
+
+        filename : str
+            data filepath.
+
+        zt : float, optional
+            target ZT. Default: 2.
+        direction : str, optional
+            crystal direction, accepts x-z/ a-c or average/ avg.
+            Default: average.
+        doping : str, optional
+            doping type for BoltzTraP. Must be n or p. Default: n.
+
+        tinterp : int, optional
+            density of interpolation for temperature. None turns it off.
+            Default: 200.
+        dinterp : int, optional
+            density of interpolation for doping. None turns it off.
+            Default: 200.
+        kind : str, optional
+            interpolation kind. Default: linear.
+
+        output : str, optional
+            output filename (no extension). Default: tp-kappa-target.
+        force : bool, optional
+            force overwrite input file. Default: False.
+
+    Returns
+    -------
+
+        none
+            instead writes to hdf5.
+    """
+
+    if not force:
+        prompt(filename, '{}.hdf5'.format(output))
+
+    try:
+        data = tp.data.load.amset(filename)
+    except Exception:
+        data = tp.data.load.boltztrap(filename, doping=doping)
+    data = tp.data.resolve.resolve(data, ['conductivity', 'seebeck',
+                                   'electronic_thermal_conductivity'],
+                                   direction=direction)
+    data['zt'] = zt
+
+    data = tp.calculate.kl_fromdict(data)
+
+    kdata = {'meta': {**data['meta'],
+                     'original_temperature': data['temperature'][()],
+                     'original_doping':      data['doping'][()]}}
+    # interpolation of kl (if applicable)
+    if tinterp is not None or dinterp is not None:
+        if tinterp is None:
+            kdata['temperature'] = data['temperature'][()]
+        else:
+            kdata['temperature'] = np.linspace(data['temperature'][0],
+                                               data['temperature'][-1],
+                                               tinterp)
+        if dinterp is None:
+            kdata['doping'] = data['doping'][()]
+        else:
+            kdata['doping'] = np.geomspace(data['doping'][0],
+                                           data['doping'][-1], dinterp)
+
+        kinterp = interp2d(data['doping'], data['temperature'],
+                           data['electronic_thermal_conductivity'], kind=kind)
+        kdata['lattice_thermal_conductivity'] = kinterp(kdata['doping'],
+                                                        kdata['temperature'])
+    else:
+        kdata['lattice_thermal_conductivity'] = \
+                                       data['lattice_thermal_conductivity'][()]
+        kdata['temperature'] = data['temperature'][()]
+        kdata['doping'] = data['doping'][()]
+
+    hdf5(kdata, '{}.hdf5'.format(output))
+
+    return
 
 def hdf5(data, output):
     """Saves to hdf5.
@@ -39,5 +311,47 @@ def hdf5(data, output):
             datafile.create_dataset(key, np.shape(data[key]), data=data[key])
 
     datafile.close()
+
+    return
+
+def prompt(filename, output):
+    """Prompts before overwrite.
+
+    Arguments
+    ---------
+
+        filename : str
+            input filename.
+        output : str or list
+            output filename(s).
+
+    Returns
+    -------
+
+        none
+    """
+
+    if isinstance(output, str):
+        output = [output]
+    if filename in output:
+        tries = 3
+        while True:
+            print('Warning: this will overwrite {}. Continue?'.format(filename))
+            cont = input('[y/n]').lower()
+            if cont in ['y', 'ye', 'yes']:
+                print('Continuing...')
+                break
+            elif cont in ['n', 'no']:
+                print('Aborting!')
+                exit()
+            else:
+                tries -= 1
+                if tries == 2:
+                    print('Invalid response. 2 tries remain.')
+                elif tries == 1:
+                    print('Invalid response. 1 try remains.')
+                else:
+                    print('Invalid response. Aborting!')
+                    exit()
 
     return

--- a/tp/plot/colour.py
+++ b/tp/plot/colour.py
@@ -92,7 +92,7 @@ def uniform(cmid, cmin='#ffffff', cmax='#000000', alpha=1.,
     cmax2 = np.array(rgb2array(cmax, alpha))
     cnorm = (cmid2[:3] - cmin2[:3]) / (cmax2[:3] - cmin2[:3])
     # pythagoras
-    midpoint = np.sqrt(((1-cnorm[0])**2 + (1-cnorm[1])**2 + (1-cnorm[2])**2)/3)
+    midpoint = np.sqrt((cnorm[0]**2 + cnorm[1]**2 + cnorm[2]**2)/3)
     x = [0, midpoint, 1]
     y = [cmin2, cmid2, cmax2]
     colours = []

--- a/tp/plot/heatmap.py
+++ b/tp/plot/heatmap.py
@@ -205,11 +205,10 @@ def add_heatmap(ax, x, y, c, xinterp=None, yinterp=None, kind='linear',
 
 def add_ztmap(ax, data, kdata=None, direction='avg', xinterp=200,
               yinterp=200, kind='linear', xmin=None, xmax=None, ymin=None,
-              ymax=None, cmin=None, cmax=None, colour='viridis',
-              output='zt.hdf5', **kwargs):
+              ymax=None, cmin=None, cmax=None, colour='viridis', **kwargs):
     """Convenience wrapper for plotting ZT heatmaps.
 
-    Calculates ZT and writes to hdf5, plots and formats labels etc.
+    Calculates ZT, plots and formats labels etc.
 
     Arguments
     ---------
@@ -225,8 +224,8 @@ def add_ztmap(ax, data, kdata=None, direction='avg', xinterp=200,
             temperature. Ignored if zt in data, if not ignored and None,
             defaults to 1 at all temperatures.
         direction : str, optional
-            direction from anisotropic data, accepts x-z/ a-c or
-            average/ avg. Default: average.
+            crystal direction, accepts x-z/ a-c or average/ avg.
+            Default: average.
 
         xinterp : int, optional
             density of interpolation. None turns it off. Default: 200.
@@ -250,12 +249,6 @@ def add_ztmap(ax, data, kdata=None, direction='avg', xinterp=200,
         colour : colourmap or str or array-like, optional
             colourmap or colourmap name; or key colour or min and max
             RGB colours to generate a colour map. Default: viridis.
-
-        output : str, optional
-            output filename to write to. Only writes if ZT has been
-            within this function. Set to None to not write. Can be
-            loaded with h5py.File to put back into this function.
-            Default: zt.hdf5.
 
         kwargs
             keyword arguments passed to matplotlib.pyplot.pcolormesh.
@@ -330,9 +323,6 @@ def add_ztmap(ax, data, kdata=None, direction='avg', xinterp=200,
 
         data = tp.calculate.zt_fromdict(data)
 
-        if output is not None:
-            tp.data.save.hdf5(data, output)
-
     # plotting
 
     cbar = add_heatmap(ax, data['temperature'], list(np.abs(data['doping'])),
@@ -353,7 +343,7 @@ def add_ztmap(ax, data, kdata=None, direction='avg', xinterp=200,
 def add_kappa_target(ax, data, zt=2, direction='avg', xinterp=200,
                      yinterp=200, kind='linear', xmin=None, xmax=None,
                      ymin=None, ymax=None, cmin=0, cmax=None, colour='viridis',
-                     output='target-kl.hdf5', **kwargs):
+                     **kwargs):
     """Plots a heatmap of k_latt required for a target ZT
 
     Calculates lattice thermal conductivity, plots and formats labels
@@ -371,8 +361,8 @@ def add_kappa_target(ax, data, zt=2, direction='avg', xinterp=200,
         zt : float, optional
             target ZT. Default: 2.
         direction : str, optional
-            direction from anisotropic data, accepts x-z/ a-c or
-            average/ avg. Default: average.
+            crystal direction, accepts x-z/ a-c or average/ avg.
+            Default: average.
 
         xinterp : int, optional
             density of interpolation. None turns it off. Default: 200.
@@ -396,10 +386,6 @@ def add_kappa_target(ax, data, zt=2, direction='avg', xinterp=200,
         colour : colourmap or str or array-like, optional
             colourmap or colourmap name; or key colour or min and max
             RGB colours to generate a colour map. Default: viridis.
-
-        output : str, optional
-            output filename to write to. Set to None to not write.
-            Default: target-kl.hdf5.
 
         kwargs
             keyword arguments passed to matplotlib.pyplot.pcolormesh.
@@ -435,9 +421,6 @@ def add_kappa_target(ax, data, zt=2, direction='avg', xinterp=200,
     data['zt'] = zt
 
     data = tp.calculate.kl_fromdict(data)
-
-    if output is not None:
-        tp.data.save.hdf5(data, output)
 
     # plotting
 

--- a/tp/plot/heatmap.py
+++ b/tp/plot/heatmap.py
@@ -173,7 +173,11 @@ def add_heatmap(ax, x, y, c, xinterp=None, yinterp=None, kind='linear',
         if yinterp is not None:
             if yscale == 'linear': y = np.linspace(y[0], y[-1], yinterp)
             if yscale == 'log': y = np.geomspace(y[0], y[-1], yinterp)
+        x = np.array(x)
+        y = np.array(y)
         c = cinterp(x, y)
+    else:
+        c = np.transpose(c)
 
     # ensure all data is shown
     if len(x) == len(c[0]):
@@ -190,7 +194,6 @@ def add_heatmap(ax, x, y, c, xinterp=None, yinterp=None, kind='linear',
             y.append(y[-1] ** 2 / y[-2])
 
     # plotting
-
     heat = ax.pcolormesh(x, y, c, cmap=colours, norm=cnorm, **kwargs)
     cbar = plt.colorbar(heat, extend=extend)
 


### PR DESCRIPTION
Separates the data-writing and plotting sections, so hdf5 files of e.g. zt are not automatically written on plotting, and can be written without plotting anything using the new functions in `tp.data.save`. Also stabilises the file handling (loading and writing portions) by using the `with ... as ...` syntax. When running BoltzTraP, the intemediary data can be written in a chosen place using the `run_dir` argument, and deleted automatically using the `clean` argument.