### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,9 @@ ThermoPlotter can easily be installed with git and pip:
 
 .. code-block:: bash
 
-    git clone git@github.com:SMTG-UCL/ThermoPlotter.git
+    git clone https://github.com/SMTG-UCL/ThermoPlotter.git
     cd ThermoPlotter
-    python3 -m pip install --user .
+    pip install .
 
 After installing, you may want to copy ``ThermoPlotter/tprc.yaml`` to
 ``~/.config/tprc.yaml``, if you want to set your own default axis


### PR DESCRIPTION
Update the instructions for installation:
- use the https link for cloning - otherwise it does not work for those not having ssh public key access. 
- `pip install` should not have the `--user` options, as most likely it is going to be installed into a virtual environment.